### PR TITLE
Change Name, Micro-Optimize, Error Handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
+const browserify = require('browserify')
+
 module.exports = function () {
-  const browserify = (_, opts, cb) => {
-    const compiler = require("browserify")(opts)
+  const compile = (compiler, cb) => {
     return this.unwrap((files) => {
       files.forEach(file => compiler.add(file))
       compiler.bundle(function (err, buf) {
@@ -9,7 +10,8 @@ module.exports = function () {
       })
     })
   }
-  this.filter("browserify", (source, options) =>
-    this.defer(browserify.bind(this))(source, options)
-  )
+  this.filter('browserify', (source, options) => {
+    const b = browserify(options)
+    return this.defer(compile.bind(this))(b)
+  })
 }

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const browserify = require("browserify")
 function compile(compiler, cb) {
   return this.unwrap((files) => {
     files.forEach(file => compiler.add(file))
-    compiler.bundle(function (err, buf) {
+    compiler.bundle((err, buf) => {
       if (err) {
         return this.emit("plugin_error", {
           plugin: "fly-browserify",

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = function () {
       })
     })
   }
-  this.filter("browse", (source, options) =>
+  this.filter("browserify", (source, options) =>
     this.defer(browserify.bind(this))(source, options)
   )
 }

--- a/index.js
+++ b/index.js
@@ -1,16 +1,17 @@
-const browserify = require('browserify')
+const browserify = require("browserify")
 
-module.exports = function () {
-  const compile = (compiler, cb) => {
-    return this.unwrap((files) => {
-      files.forEach(file => compiler.add(file))
-      compiler.bundle(function (err, buf) {
-        if (err) throw err
-        cb(null, buf.toString())
-      })
+function compile(compiler, cb) {
+  return this.unwrap((files) => {
+    files.forEach(file => compiler.add(file))
+    compiler.bundle(function (err, buf) {
+      if (err) throw err
+      cb(null, buf.toString())
     })
-  }
-  this.filter('browserify', (source, options) => {
+  })
+}
+
+module.exports = function() {
+  this.filter("browserify", (source, options) => {
     const b = browserify(options)
     return this.defer(compile.bind(this))(b)
   })

--- a/index.js
+++ b/index.js
@@ -4,10 +4,22 @@ function compile(compiler, cb) {
   return this.unwrap((files) => {
     files.forEach(file => compiler.add(file))
     compiler.bundle(function (err, buf) {
-      if (err) throw err
+      if (err) {
+        return this.emit("plugin_error", {
+          plugin: "fly-browserify",
+          error: getError(err.message, this.root)
+        })
+      }
+
       cb(null, buf.toString())
     })
   })
+}
+
+function getError(msg, basedir) {
+  return msg.replace(RegExp(basedir, "g"), "")
+    .replace(": ", ": \n\n  ")
+    .replace(" while parsing", "\n\nwhile parsing") + "\n"
 }
 
 module.exports = function() {


### PR DESCRIPTION
1. Change name to "browserify", because convention. Resolves #3 
2. The full definition doesn't have to be inside `module.exports`. This _slightly_ improves performance by 8-15ms... it's Fly, we'll take all the speed we can get :wink: 
3. Most importantly, will not kill the entire Fly instance if there is a compilation fatal error. Instead, it will output the error message & wait for resolution. Critical for `fly.watch` -type tasks.
